### PR TITLE
fix: constant in the template argument

### DIFF
--- a/parser.cc
+++ b/parser.cc
@@ -1129,8 +1129,8 @@ std::string Parser::ParseTypeNodeDeclarator()
     // Mark that this is not the first time in this loop
     first = false;
 
-    // Match an identifier
-    if (!GetIdentifier(token))
+    // Match an identifier or constant
+    if (!GetIdentifier(token) && !GetConst(token))
       throw; // Expected identifier
 
     declarator += token.token;


### PR DESCRIPTION
The template argument could contain a constant such as `std::array<int, 3>`. This PR will try to resolve the case by double checking with `GetConst()` since the `GetIdentifier()` and `GetConst()` does `UngetToken()` if there is no match.
